### PR TITLE
Eliminate (most) warnings

### DIFF
--- a/OpenGL2dEx/main.cpp
+++ b/OpenGL2dEx/main.cpp
@@ -111,8 +111,8 @@ int main(int argc, char *argv[])
 	{
 		// calculate delta time
 		auto current_frame = glfwGetTime();
-		delta_time = current_frame - last_frame;
-		last_frame = current_frame;
+		delta_time = static_cast<float>(current_frame) - last_frame;
+		last_frame = static_cast<float>(current_frame);
 		glfwPollEvents();
 
 		// manage user input

--- a/OpenGL2dEx/util/game.cpp
+++ b/OpenGL2dEx/util/game.cpp
@@ -165,8 +165,8 @@ namespace util
 	{
 		auto &renderer = ResourceManager::get_font(default_font_id_);
 		// TODO(sasiala): pos x should be based off of width
-		renderer.render_text("Press ENTER to start", 250.0f, height_ / 2, 1.0f, {});
-		renderer.render_text("Press W or S to select level", 245.0f, height_ / 2 + 20.0f, 0.75f, {});
+		renderer.render_text("Press ENTER to start", 250.0f, height_ / 2.0f, 1.0f, {});
+		renderer.render_text("Press W or S to select level", 245.0f, height_ / 2.0f + 20.0f, 0.75f, {});
 	}
 
 } // namespace util

--- a/OpenGL2dEx/util/game.h
+++ b/OpenGL2dEx/util/game.h
@@ -48,7 +48,7 @@ namespace util {
 
 	private:
 		// GameViewport::GameStateCallback
-		void game_ended_impl(const EndingReason reason) override;
+		void game_ended_impl(EndingReason reason) override;
 
 		void load_current_level();
 

--- a/OpenGL2dEx/util/game_viewport.cpp
+++ b/OpenGL2dEx/util/game_viewport.cpp
@@ -204,7 +204,7 @@ namespace util {
 		render_lives();
 
 		effects_->end_render();
-		effects_->render(glfwGetTime());
+		effects_->render(static_cast<float>(glfwGetTime()));
 
 		check_for_gl_errors();
 	}

--- a/OpenGL2dEx/util/game_viewport.h
+++ b/OpenGL2dEx/util/game_viewport.h
@@ -41,7 +41,7 @@ public:
 			kNumReasons,
 			kUnknown,
 		};
-		void game_ended(const EndingReason reason)
+		void game_ended(EndingReason reason)
 		{
 			game_ended_impl(reason);
 		}
@@ -185,7 +185,7 @@ private:
 
 	TextRenderer::FontSize font_size() const
 	{
-		return kDefaultRelativeFontSize * height_;
+		return static_cast<TextRenderer::FontSize>(kDefaultRelativeFontSize * height_);
 	}
 
 	IResetGlProperties &gl_property_resetter_;

--- a/OpenGL2dEx/util/optional.h
+++ b/OpenGL2dEx/util/optional.h
@@ -54,7 +54,7 @@ namespace util {
 
 		// TODO(sasiala): implement comparison operators
 
-		constexpr Optional& operator=(const Optional &other)
+		constexpr Optional& operator=(const Optional &other) const
 		{
 			if (!has_data_ && !other.has_data_)
 			{

--- a/OpenGL2dEx/util/post_processor.h
+++ b/OpenGL2dEx/util/post_processor.h
@@ -3,6 +3,7 @@
 
 #include "resource_mgr.h"
 #include "shader.h"
+#include "types.h"
 
 #include "glm/glm.hpp"
 
@@ -58,7 +59,7 @@ public:
 		confuse_ = chaos_ = shake_ = false;
 	}
 
-	void set_size(const float width, const float height)
+	void set_size(const Dimension width, const Dimension height)
 	{
 		width_ = width;
 		height_ = height;
@@ -77,8 +78,8 @@ private:
 	Shader post_processing_shader_;
 	Texture2D texture_;
 	glm::vec2 position_;
-	unsigned int width_;
-	unsigned int height_;
+	Dimension width_;
+	Dimension height_;
 
 	bool confuse_;
 	bool chaos_;

--- a/OpenGL2dEx/util/text_renderer.cpp
+++ b/OpenGL2dEx/util/text_renderer.cpp
@@ -106,7 +106,7 @@ void TextRenderer::load(const char *font_path,
 	FT_Done_FreeType(ft);
 }
 
-void TextRenderer::update_size(float width, float height) const
+void TextRenderer::update_size(Dimension width, Dimension height) const
 {
 	shader_->use();
 	shader_->set_mat4("u_projection_", make_ortho(width, height), false);

--- a/OpenGL2dEx/util/text_renderer.h
+++ b/OpenGL2dEx/util/text_renderer.h
@@ -53,7 +53,7 @@ public:
 	}
 
 	void load(const char *font_path, FontSize font_size);
-	void update_size(float width, float height) const;
+	void update_size(Dimension width, Dimension height) const;
 	void render_text(const std::string &text, 
 					 float x, 
 					 float y, 

--- a/OpenGL2dEx/util/texture_2d.cpp
+++ b/OpenGL2dEx/util/texture_2d.cpp
@@ -18,8 +18,8 @@ namespace util {
 		ASSERT(id_ != 0, "Texture not properly generated");
 	}
 
-	void Texture2D::generate(const unsigned int width, 
-							 const unsigned int height, 
+	void Texture2D::generate(const Dimension width, 
+							 const Dimension height, 
 							 unsigned char		*data,
 							 bool               allow_no_data)
 	{

--- a/OpenGL2dEx/util/texture_2d.h
+++ b/OpenGL2dEx/util/texture_2d.h
@@ -1,6 +1,8 @@
 #ifndef TEXTURE_2D_H
 #define TEXTURE_2D_H
 
+#include "types.h"
+
 namespace util {
 
 // Texture2D is able to store and configure a texture in OpenGL.
@@ -22,8 +24,8 @@ public:
 	{
 	}
 
-	void generate(unsigned int width, 
-				  unsigned int height, 
+	void generate(Dimension      width, 
+				  Dimension      height, 
 				  unsigned char* data,
 				  bool           allow_no_data = false);
 
@@ -70,8 +72,8 @@ private:
 	unsigned int id_;
 
 	// texture image dimensions
-	unsigned int width_; // width of loaded image in pixels
-	unsigned int height_; // height of loaded image in pixels
+	Dimension width_; // width of loaded image in pixels
+	Dimension height_; // height of loaded image in pixels
 
 	// texture format
 	unsigned int internal_format_; // format of texture object


### PR DESCRIPTION
I've eliminated most of the warnings in the code.  There's one warning sticking around that seems to be due to a mismatch with one of the libraries I'm using.  Additionally, I've created a task to reconsider the uses of static_cast added here.